### PR TITLE
adding raw irc command to get JOIN/PART messages

### DIFF
--- a/src/twitch.coffee
+++ b/src/twitch.coffee
@@ -69,6 +69,7 @@ class Twitch extends Adapter
     client.addListener "notice", @onNotice
     client.addListener "part", @onPart
     client.addListener "quit", @onQuit
+    client.send("raw CAP REQ :twitch.tv/membership")
 
     @ircClient = client
 


### PR DESCRIPTION
This allows the robot.enter and robot.leave functions to operate as a developer might expect them.

Taken from IRC configuration explained [here](http://help.twitch.tv/customer/portal/articles/1302780-twitch-irc)
Search for "JOINS/PARTS - General"
